### PR TITLE
Add support for attributes properties

### DIFF
--- a/BanItemPlugin/src/main/java/fr/andross/banitem/items/meta/AttributeContains.java
+++ b/BanItemPlugin/src/main/java/fr/andross/banitem/items/meta/AttributeContains.java
@@ -1,0 +1,168 @@
+/*
+ * BanItem - Lightweight, powerful & configurable per world ban item plugin
+ * Copyright (C) 2021 André Sustac
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your action) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.andross.banitem.items.meta;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import fr.andross.banitem.utils.BanVersion;
+import fr.andross.banitem.utils.ReflectionUtils;
+import fr.andross.banitem.utils.attributes.*;
+import fr.andross.banitem.utils.debug.Debug;
+import fr.andross.banitem.utils.list.Listable;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A simple meta comparator to compare attributes
+ * @version 3.4
+ * @author EpiCanard
+ */
+public final class AttributeContains extends MetaTypeComparator {
+    private final Multimap<Object, AttributeLevels> attributes = HashMultimap.create();
+
+    public AttributeContains(final Object o, final Debug debug) {
+        super(o);
+        final List<String> configAttributes = Listable.getSplittedStringList(o);
+
+        for (final String attr : configAttributes) {
+            final String[] s = attr.split(":");
+
+            if (s.length <= 0) return;
+
+            // Extract attribute
+            final Object attribute = getAttributeKey(s[0], debug);
+            if (attribute == null) return;
+
+            // 'Attribute': if the item contains this enchantment, does not consider the level;
+            if (s.length == 1) {
+                attributes.put(attribute, null);
+                continue;
+            }
+
+            // 'Attribute:Level': if the item contains this enchantment with this level;
+            if (s.length == 2) {
+                final AttributeLevels.Comparator comparator = AttributeLevels.Comparator.fromString(s[1].substring(0, 1));
+                final String value = (comparator == AttributeLevels.Comparator.EQUALS) ? s[1]: s[1].substring(1);
+
+                final Double level = parseLevel(value, debug);
+                if (level == null) return;
+
+                attributes.put(attribute, new AttributeLevels(level, comparator));
+                continue;
+            }
+
+            // 'Attribute:MinLevel:MaxLevel': if the item contains this enchantment, within the min & max level interval [inclusive];
+            final Double minLevel = parseLevel(s[1], debug);
+            if (minLevel == null) return;
+            final Double maxLevel = parseLevel(s[2], debug);
+            if (maxLevel == null) return;
+
+            attributes.put(attribute, new AttributeLevels(minLevel, maxLevel));
+        }
+    }
+
+    @Override
+    public boolean matches(@NotNull final ItemStack itemStack, @Nullable final ItemMeta itemMeta) {
+        if (itemMeta == null) return false;
+        return getAttributesModifiers(itemStack).entries().stream()
+                .filter(entry -> attributes.containsKey(entry.getKey()))
+                .anyMatch(entry -> attributes.get(entry.getKey()).stream()
+                            .anyMatch(levels -> levels == null || levels.matches(entry.getValue())));
+    }
+
+    /**
+     * Get the attribute from config string
+     * @param attributeName Name of attribute to find
+     * @param debug Debug
+     * @return The Attribute found or null
+     */
+    @Nullable
+    private Object getAttributeKey(@NotNull final String attributeName, @NotNull final Debug debug) {
+        try {
+            return (BanVersion.v9OrMore) ? Attribute.valueOf(attributeName) : AttributeLegacy.valueOf(attributeName);
+        } catch (final IllegalArgumentException e) {
+            invalidateMetaType(debug, "Unknown attribute '" + attributeName + "'.");
+            return null;
+        }
+    }
+
+    /**
+     * Extract attributes modifiers from item
+     * @param itemStack ItemStack
+     * @return A Multimap of attribute name and amount
+     */
+    @NotNull
+    private Multimap<Object, Double> getAttributesModifiers(@NotNull final ItemStack itemStack) {
+        final Multimap<Object, Double> map = HashMultimap.create();
+        if (BanVersion.v9OrMore) {
+            // Extract attributes with bukkit api
+            if (itemStack.getItemMeta() != null && itemStack.getItemMeta().getAttributeModifiers() != null) {
+                itemStack.getItemMeta().getAttributeModifiers().entries().forEach(entry ->
+                    map.put(entry.getKey(), entry.getValue().getAmount())
+                );
+            }
+        } else {
+            // Extract attributes with reflection from NMSItemStack (MC <1.9)
+            try {
+                final Object nmsItemStack = ReflectionUtils.asNMSCopy(itemStack);
+                final Multimap<String, Object> multimap = ReflectionUtils.callMethodWithReturnType(nmsItemStack, Multimap.class);
+                for (Map.Entry<String, Object> entry : multimap.entries()) {
+                    final AttributeLegacy attribute = AttributeLegacy.valueFromName(entry.getKey());
+                    if (attribute != null)
+                        map.put(attribute, ReflectionUtils.callMethodWithName(entry.getValue(), "d"));
+                }
+            } catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+                e.printStackTrace();
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Parse the level from String to Double
+     * @param level String level to parse
+     * @param debug Debug
+     * @return the parsed level or null
+     */
+    @Nullable
+    private Double parseLevel(@NotNull final String level, @NotNull final Debug debug) {
+        try {
+            return Double.parseDouble(level);
+        } catch (final NumberFormatException e) {
+            invalidateMetaType(debug, "Invalid level '" + level + "'.");
+            return null;
+        }
+    }
+
+    /**
+     * Send the debug message and invalid the comparator
+     * @param debug Debug
+     * @param message Error message to send
+     */
+    private void invalidateMetaType(@NotNull final Debug debug, @NotNull final String message) {
+        debug.clone().add("&c" + message).sendDebug();
+        setValid(false);
+    }
+}

--- a/BanItemPlugin/src/main/java/fr/andross/banitem/items/meta/MetaType.java
+++ b/BanItemPlugin/src/main/java/fr/andross/banitem/items/meta/MetaType.java
@@ -39,7 +39,8 @@ public enum MetaType {
     MODELDATA_EQUALS(ModeldataEquals.class),
     NBTAPI(NBTAPI.class),
     POTION(Potion.class),
-    UNBREAKABLE(Unbreakable.class);
+    UNBREAKABLE(Unbreakable.class),
+    ATTRIBUTE(AttributeContains.class);
 
     private final Class<? extends MetaTypeComparator> clazz;
 

--- a/BanItemPlugin/src/main/java/fr/andross/banitem/utils/ReflectionUtils.java
+++ b/BanItemPlugin/src/main/java/fr/andross/banitem/utils/ReflectionUtils.java
@@ -1,0 +1,81 @@
+/*
+ * BanItem - Lightweight, powerful & configurable per world ban item plugin
+ * Copyright (C) 2021 André Sustac
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your action) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.andross.banitem.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Package utils that use the reflection api of java
+ * @version 3.4
+ * @author EpiCanard
+ */
+public class ReflectionUtils {
+
+    private final static String bukkitPackageVersion;
+
+    static {
+        // Bukkit package version (ex: V1_8_R3)
+        bukkitPackageVersion = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+    }
+
+    /**
+     * Create an NMSItemStack from Bukkit ItemStack
+     * @param itemStack Bukkit ItemStack to convert
+     * @return Converted ItemStack
+     */
+    public static Object asNMSCopy(@NotNull final ItemStack itemStack) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        final String craftPath = String.format("org.bukkit.craftbukkit.%s.inventory.CraftItemStack", bukkitPackageVersion);
+        final Class<?> craftItemStack =  Class.forName(craftPath);
+        final Method asNMSCopy = craftItemStack.getDeclaredMethod("asNMSCopy", ItemStack.class);
+        return asNMSCopy.invoke(null, itemStack);
+    }
+
+    /**
+     * Call the first method matching the returnType
+     * @param obj Object that contains the method
+     * @param returnType Return type class that must be returned by the method
+     * @param <T> Return type
+     * @return The value returned by the call to the method
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T callMethodWithReturnType(@NotNull final Object obj, @NotNull final Class<? extends T> returnType) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        final Optional<Method> maybeMethod = Arrays.stream(obj.getClass().getDeclaredMethods()).filter(m -> m.getReturnType() == returnType).findFirst();
+        if (maybeMethod.isPresent())
+            return (T)maybeMethod.get().invoke(obj);
+        throw new NoSuchMethodException("Can't find method with type : " + returnType.getName());
+    }
+
+    /**
+     * Call the first method matching the name
+     * @param obj Object that contains the method
+     * @param name Name of method to call
+     * @param <T> Return type
+     * @return The value returned by the call to the method
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T callMethodWithName(@NotNull final Object obj, @NotNull final String name) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return (T)obj.getClass().getDeclaredMethod(name).invoke(obj);
+    }
+}

--- a/BanItemPlugin/src/main/java/fr/andross/banitem/utils/attributes/AttributeLegacy.java
+++ b/BanItemPlugin/src/main/java/fr/andross/banitem/utils/attributes/AttributeLegacy.java
@@ -1,0 +1,65 @@
+/*
+ * BanItem - Lightweight, powerful & configurable per world ban item plugin
+ * Copyright (C) 2021 André Sustac
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your action) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.andross.banitem.utils.attributes;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * An enum which represents the minecraft attributes.
+ * Only useful for Minecraft lower to 1.9
+ * @version 3.4
+ * @author EpiCanard
+ */
+public enum AttributeLegacy {
+    GENERIC_MAX_HEALTH("generic.maxHealth"),
+    GENERIC_FOLLOW_RANGE("generic.followRange"),
+    GENERIC_KNOCKBACK_RESISTANCE("generic.knockbackResistance"),
+    GENERIC_MOVEMENT_SPEED("generic.movementSpeed"),
+    GENERIC_FLYING_SPEED("generic.flyingSpeed"),
+    GENERIC_ATTACK_DAMAGE("generic.attackDamage"),
+    GENERIC_ATTACK_SPEED("generic.attackSpeed"),
+    GENERIC_ARMOR("generic.armor"),
+    GENERIC_ARMOR_TOUGHNESS("generic.armorToughness"),
+    GENERIC_LUCK("generic.luck"),
+    HORSE_JUMP_STRENGTH("horse.jumpStrength"),
+    ZOMBIE_SPAWN_REINFORCEMENTS("zombie.spawnReinforcements");
+
+    private final String name;
+
+    AttributeLegacy(@NotNull final String name) {
+        this.name = name;
+    }
+
+    @NotNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Retrieve an AttributeLegacy from its name
+     * @param name Name of attribute to find
+     * @return the AttributeLegacy matching or null
+     */
+    @Nullable
+    public static AttributeLegacy valueFromName(final String name) {
+        return Arrays.stream(AttributeLegacy.values()).filter(attr -> attr.name.equals(name)).findFirst().orElse(null);
+    }
+}

--- a/BanItemPlugin/src/main/java/fr/andross/banitem/utils/attributes/AttributeLevels.java
+++ b/BanItemPlugin/src/main/java/fr/andross/banitem/utils/attributes/AttributeLevels.java
@@ -1,0 +1,90 @@
+/*
+ * BanItem - Lightweight, powerful & configurable per world ban item plugin
+ * Copyright (C) 2021 André Sustac
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your action) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.andross.banitem.utils.attributes;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An attribute wrapper class that stores the levels and the comparator in which the attribute must match
+ * @version 3.4
+ * @author EpiCanard
+ */
+public final class AttributeLevels {
+    /**
+     * An enum to define how to compare attribute levels
+     */
+    public enum Comparator {
+        BETWEEN,
+        EQUALS,
+        LOWER,
+        HIGHER;
+
+        /**
+         * Retrieve a Comparator from a string sign
+         * @param operator Operator as string
+         * @return The Comparator that match with operator
+         */
+        @NotNull
+        public static Comparator fromString(@NotNull final String operator) {
+            switch (operator) {
+                case ">":
+                    return HIGHER;
+                case "<":
+                    return LOWER;
+                default:
+                    return EQUALS;
+            }
+        }
+    }
+
+    private final Comparator comparator;
+    private final Double minLevel;
+    private final Double maxLevel;
+
+    public AttributeLevels(@NotNull final Double level, @NotNull final Comparator comparator) {
+        this.comparator = comparator;
+        this.minLevel = level;
+        this.maxLevel = null;
+    }
+
+    public AttributeLevels(@NotNull final Double minLevel, @NotNull final Double maxLevel) {
+        this.comparator = Comparator.BETWEEN;
+        this.minLevel = minLevel;
+        this.maxLevel = maxLevel;
+    }
+
+    /**
+     * Define if the param level match with the attribute levels
+     * @param level Level to check if it matches
+     * @return if the input level match
+     */
+    @NotNull
+    public Boolean matches(@NotNull final Double level) {
+        switch (this.comparator) {
+            case BETWEEN:
+                return level >= minLevel && (maxLevel == null || level <= maxLevel);
+            case EQUALS:
+                return level.equals(minLevel);
+            case LOWER:
+                return level < minLevel;
+            case HIGHER:
+                return level > minLevel;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Hello Andross96,

Here is a contribution to add support for Attributes ([minecraft wiki](https://minecraft.fandom.com/wiki/Attribute)).

I added a MetaTypeComparator for attribute that works more or less like EnchantmentContains.

### Usage
The values that should be used in the config must match with the following enum : [Attribute](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html)

It can be used in different ways :
- `GENERIC_ATTACK_DAMAGE` => Any items with this attribute
- `GENERIC_ATTACK_DAMAGE:10.2` => Equals to 10.2
- `GENERIC_ATTACK_DAMAGE:>10` => Higher to 10
- `GENERIC_ATTACK_DAMAGE:<10` => Lower to 10
- `GENERIC_ATTACK_DAMAGE:10:20 ` => Between 10 and 10

### Example
A full example of config :
```yaml
customItemName:
  material: '*'
  attribute: 'GENERIC_FLYING_SPEED,GENERIC_ATTACK_SPEED:4,GENERIC_ATTACK_KNOCKBACK,GENERIC_ATTACK_DAMAGE:>13,GENERIC_ARMOR_TOUGHNESS:1:3,GENERIC_ARMOR:<8' 
```

### Documentation
Note for documentation :
Remember that some item and enchants add some attributes so it can be a good idea to add more strict rules. For example : `GENERIC_ATTACK_DAMAGE:>13` instead of `GENERIC_ATTACK_DAMAGE`

### NB Legacy
The current state of the work support from Minecraft 1.8 to 1.18. Sadly it doesn't support Minecraft 1.7 because in this version all dependencies are packaged with a prefix.

For example, the class `com.google.common.collect.Multimap` I try to get from a method in the NMSItemStack is located in package `net.minecraft.util.com.google.common.collect.Multimap`

So if you want to add support for this version you will have to do a specific piece of code just for this version.


Don't hesitate if you have any question.

Best regards